### PR TITLE
Media service name must be alphanumeric

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   rg_name      = "${var.product}-media-service-${var.env}"
   sa_name      = "${var.product}mediaservice${var.env}"
-  service_name = "${var.product}-media-service-${var.env}"
+  service_name = "${var.product}mediaservice${var.env}"
 }
 
 resource "azurerm_resource_group" "rg" {


### PR DESCRIPTION
### Change description ###
Fixes error: 

> Error: Error creating Media Service Account "dm-media-service-demo" (Resource Group "dm-media-service-demo"): media.MediaservicesClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidUrl" Message="The URL resource id cannot be applied to the resource: The field Name must match the regular expression '^[a-z0-9]{3,26}$'."

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No - As no one is using this service in prod yet
```
